### PR TITLE
Added cancel and destroy functions to MachXPCHost

### DIFF
--- a/MachXPC/MachXPCHost.h
+++ b/MachXPC/MachXPCHost.h
@@ -12,13 +12,18 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MachXPCHost : NSObject
 @property (readonly) NSString *name;
 
-- (instancetype)initWithName:(NSString *)name connectionHandler:(void(^)(NSString *serviceIdentifier, NSXPCListenerEndpoint *listener))handler;
+- (instancetype)initWithName:(NSString *)name connectionHandler:(void (^)(NSString *serviceIdentifier, NSXPCListenerEndpoint *listener))handler;
 
-- (instancetype)initWithConnectionHandler:(void(^)(NSString *serviceIdentifier, NSXPCListenerEndpoint *listener))handler;
+- (instancetype)initWithConnectionHandler:(void (^)(NSString *serviceIdentifier, NSXPCListenerEndpoint *listener))handler;
 
 - (void)suspend;
 
 - (void)resume;
+
+- (void)cancel;
+
+- (void)destroy;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/MachXPC/MachXPCHost.m
+++ b/MachXPC/MachXPCHost.m
@@ -20,93 +20,111 @@ xpc_endpoint_t (*_xpc_endpoint_create)(mach_port_t);
 @interface MachXPCHost ()
 @property (nonatomic, copy, nonnull) void (^handler)(NSString *serviceIdentifier, NSXPCListenerEndpoint *);
 @property (nonnull) dispatch_queue_t listenerQueue;
-@property (nonnull) dispatch_source_t   dispatchSrc;
+@property (nonnull) dispatch_source_t dispatchSrc;
 @end
 
 @implementation MachXPCHost {
-    mach_port_t         _server_port;
+	mach_port_t _server_port;
 }
 
 - (void)_setupEndpointWithPort:(mach_port_t)port forService:(NSString *)service {
-    if(port == -1 || port == 0) {
-        _handler(nil, nil);
-        return;
-    }
-    
-    xpc_endpoint_t xpcEndpoint = _xpc_endpoint_create(port);
-    NSXPCListenerEndpoint *listener = [[NSXPCListenerEndpoint alloc] init];
-    [listener _setEndpoint:xpcEndpoint];
-    
-    _handler(service, listener);
+	if(port == -1 || port == 0) {
+		_handler(nil, nil);
+		return;
+	}
+
+	xpc_endpoint_t xpcEndpoint = _xpc_endpoint_create(port);
+	NSXPCListenerEndpoint *listener = [[NSXPCListenerEndpoint alloc] init];
+	[listener _setEndpoint:xpcEndpoint];
+
+	_handler(service, listener);
 }
 
-- (instancetype)initWithName:(NSString *)name connectionHandler:(void(^)(NSString *serviceIdentifier, NSXPCListenerEndpoint *listener))handler {
-    self = [super init];
-    _name = name;
-    _handler = handler;
-    _listenerQueue = dispatch_queue_create([[NSString stringWithFormat:@"%@/machXPC_host_q", name] UTF8String],
-                                           DISPATCH_QUEUE_SERIAL);
+- (instancetype)initWithName:(NSString *)name connectionHandler:(void (^)(NSString *serviceIdentifier, NSXPCListenerEndpoint *listener))handler {
+	self = [super init];
+	_name = name;
+	_handler = handler;
+	_listenerQueue = dispatch_queue_create([[NSString stringWithFormat:@"%@/machXPC_host_q", name] UTF8String],
+	                                       DISPATCH_QUEUE_SERIAL);
 
-    kern_return_t kr = bootstrap_check_in(bootstrap_port, name.UTF8String, &_server_port);
-    if(kr != KERN_SUCCESS) {
-        return NULL;
-    }
-    
-    _dispatchSrc = dispatch_source_create(DISPATCH_SOURCE_TYPE_MACH_RECV, _server_port, 0, _listenerQueue);
-    dispatch_source_set_event_handler(_dispatchSrc, ^{
-        msg_format_response_r_t  recv_msg;
-        mach_msg_header_t *recv_hdr;
+	kern_return_t kr = bootstrap_check_in(bootstrap_port, name.UTF8String, &_server_port);
+	if(kr != KERN_SUCCESS) {
+		return NULL;
+	}
 
-        recv_hdr                   = &(recv_msg.header);
-        recv_hdr->msgh_remote_port = self->_server_port;
-        recv_hdr->msgh_local_port  = MACH_PORT_NULL;
-        recv_hdr->msgh_size = sizeof(recv_msg);
-        recv_msg.data.name = 0;
-        kern_return_t kr = mach_msg(recv_hdr,
-                                    MACH_RCV_MSG,
-                                    0,
-                                    recv_hdr->msgh_size,
-                                    self->_server_port,
-                                    MACH_MSG_TIMEOUT_NONE,
-                                    MACH_PORT_NULL);
+	_dispatchSrc = dispatch_source_create(DISPATCH_SOURCE_TYPE_MACH_RECV, _server_port, 0, _listenerQueue);
+	dispatch_source_set_event_handler(_dispatchSrc, ^{
+		msg_format_response_r_t recv_msg;
+		mach_msg_header_t *recv_hdr;
 
-        if(kr != KERN_SUCCESS) {
-            NSLog(@"MachXPC: Host could not receive service port");
-            return;
-        }
-        
-        char *serviceName = (char*)(void*)recv_msg.ool.address;
-        [self _setupEndpointWithPort:recv_msg.data.name forService:[NSString stringWithUTF8String:serviceName]];
-    });
-    
-    return self;
+		recv_hdr                   = &(recv_msg.header);
+		recv_hdr->msgh_remote_port = self->_server_port;
+		recv_hdr->msgh_local_port  = MACH_PORT_NULL;
+		recv_hdr->msgh_size = sizeof(recv_msg);
+		recv_msg.data.name = 0;
+		kern_return_t kr = mach_msg(recv_hdr,
+		                            MACH_RCV_MSG,
+		                            0,
+		                            recv_hdr->msgh_size,
+		                            self->_server_port,
+		                            MACH_MSG_TIMEOUT_NONE,
+		                            MACH_PORT_NULL);
+
+		if(kr != KERN_SUCCESS) {
+			NSLog(@"MachXPC: Host could not receive service port");
+			return;
+		}
+
+		char *serviceName = (char*)(void*)recv_msg.ool.address;
+		[self _setupEndpointWithPort:recv_msg.data.name forService:[NSString stringWithUTF8String:serviceName]];
+	});
+
+	return self;
 }
 
-- (instancetype)initWithConnectionHandler:(void(^)(NSString *serviceIdentifier, NSXPCListenerEndpoint *listener))handler {
-    return [self initWithName:[[NSBundle mainBundle] bundleIdentifier] connectionHandler:handler];
+- (instancetype)initWithConnectionHandler:(void (^)(NSString *serviceIdentifier, NSXPCListenerEndpoint *listener))handler {
+	return [self initWithName:[[NSBundle mainBundle] bundleIdentifier] connectionHandler:handler];
 }
 
 - (void)suspend {
-    dispatch_suspend(_dispatchSrc);
+	dispatch_suspend(_dispatchSrc);
 }
 
 - (void)resume {
-    dispatch_resume(_dispatchSrc);
+	dispatch_resume(_dispatchSrc);
+}
+
+- (void)cancel {
+	if (dispatch_source_testcancel(_dispatchSrc) != 0) {
+		return;
+	}
+
+	NSLog(@"MachXPC.cancel");
+	dispatch_source_cancel(_dispatchSrc);
+}
+
+- (void)destroy {
+	[self cancel];
+
+	NSLog(@"MachXPC.destroy: mach_port_deallocate");
+	mach_port_deallocate(mach_task_self(), _server_port);
+
+	NSLog(@"MachXPC.destroy: mach_port_destroy");
+	mach_port_destroy(mach_task_self(), _server_port);
 }
 
 - (void)dealloc {
-    dispatch_source_cancel(_dispatchSrc);
-    mach_port_deallocate(mach_task_self(), _server_port);
+	[self destroy];
 }
 
 + (void)load {
-    // For the love of god Apple just export the symbols so I don't have to keep doing this
-    symrez_t sr_xpc = symrez_new("libxpc.dylib");
-    _xpc_endpoint_create = sr_resolve_symbol(sr_xpc, "__xpc_endpoint_create");
+	// For the love of god Apple just export the symbols so I don't have to keep doing this
+	symrez_t sr_xpc = symrez_new("libxpc.dylib");
+	_xpc_endpoint_create = sr_resolve_symbol(sr_xpc, "__xpc_endpoint_create");
 #if __has_feature(ptrauth_calls)
-    _xpc_endpoint_create = ptrauth_strip(_xpc_endpoint_create, ptrauth_key_function_pointer);
-    _xpc_endpoint_create = ptrauth_sign_unauthenticated(_xpc_endpoint_create, ptrauth_key_function_pointer, 0);
+	_xpc_endpoint_create = ptrauth_strip(_xpc_endpoint_create, ptrauth_key_function_pointer);
+	_xpc_endpoint_create = ptrauth_sign_unauthenticated(_xpc_endpoint_create, ptrauth_key_function_pointer, 0);
 #endif
-    free(sr_xpc);
+	free(sr_xpc);
 }
 @end


### PR DESCRIPTION
Hello. First off thanks so much for this framework. Was just what I was looking for and saved me tons of time trying to understand XPC.

I'm developing an App Extension for Final Cut Pro, and I found that if I don't destroy the mach_port on the window closing, something gets left open and it will crash on the second launch. This PR fixes it, but since you may have other reasons for not exposing destroy to a user, I can understand either way.

Sorry, linting also did the whitespace changes here. 

Ryan